### PR TITLE
Fix unit test compilation

### DIFF
--- a/src/test/java/com/couchbase/capi/CouchbaseBehaviorTestImpl.java
+++ b/src/test/java/com/couchbase/capi/CouchbaseBehaviorTestImpl.java
@@ -54,10 +54,10 @@ public class CouchbaseBehaviorTestImpl implements CouchbaseBehavior {
         return null;
     }
 
-    public List<Object> getNodesServingPool(String pool) {
-        List<Object> nodes = null;
+    public List<Map<String, Object>> getNodesServingPool(String pool) {
+        List<Map<String, Object>> nodes = null;
         if("default".equals(pool)) {
-            nodes = new ArrayList<Object>();
+            nodes = new ArrayList<Map<String, Object>>();
 
             Map<String, Object> nodePorts = new HashMap<String, Object>();
             nodePorts.put("direct", 8091);


### PR DESCRIPTION
Cherrypick db4e5d59b75d04a0d144d91764ffc348d65755b4 from master

Update the signature of getNodesServingPool to match the interface.
Note that although the generic specification changed,
the structured of the returned data remains the same.